### PR TITLE
fix(backend): compile to CommonJS to avoid ESM extension issues on Node

### DIFF
--- a/sewago/backend/package.json
+++ b/sewago/backend/package.json
@@ -1,8 +1,7 @@
 {
   "name": "backend",
   "version": "1.0.0",
-  "main": "index.js",
-  "type": "module",
+  "main": "dist/server.js",
   "engines": {
     "node": ">=20"
   },

--- a/sewago/backend/src/server.ts
+++ b/sewago/backend/src/server.ts
@@ -1,8 +1,8 @@
 import http from "http";
-import { env } from "./config/env.js";
-import { connectToDatabase } from "./config/db.js";
-import { createApp } from "./app.js";
-import { createSocketServer } from "./socket-server.js";
+import { env } from "./config/env";
+import { connectToDatabase } from "./config/db";
+import { createApp } from "./app";
+import { createSocketServer } from "./socket-server";
 import { pathToFileURL } from "url";
 
 export async function bootstrap() {
@@ -26,7 +26,8 @@ export async function bootstrap() {
 const isDirectRun = (() => {
   try {
     const argHref = pathToFileURL(process.argv[1] ?? "").href;
-    return import.meta.url === argHref;
+    const currentFileUrl = pathToFileURL(__filename).href;
+    return currentFileUrl === argHref;
   } catch {
     return false;
   }

--- a/sewago/backend/tsconfig.json
+++ b/sewago/backend/tsconfig.json
@@ -1,19 +1,16 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["ES2020"],
-    "module": "ES2020",
+    "target": "ES2019",
+    "module": "CommonJS",
     "moduleResolution": "Node",
     "outDir": "dist",
     "rootDir": "src",
-    "strict": true,
     "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
     "resolveJsonModule": true,
-    "noFallthroughCasesInSwitch": true
+    "skipLibCheck": true,
+    "strict": true
   },
-  "include": ["src"]
+  "include": ["src/**/*"]
 }
 
 


### PR DESCRIPTION
Railway was crashing with ERR_MODULE_NOT_FOUND due to ESM extension resolution (dist/* referencing extensionless paths).

This PR switches the backend TypeScript output to CommonJS so Node's resolver handles extensionless imports.

Scripts unchanged: build = tsc -p ., start = node dist/server.js.

Verified locally: build passes; GET /api/health returns 200.