### PR TITLE
fix(frontend): disable prerender for dashboard/login and remove prisma from build

### DIFF
--- a/sewago/frontend/package.json
+++ b/sewago/frontend/package.json
@@ -17,8 +17,7 @@
     "prisma:migrate": "prisma migrate dev --name init_jules_batch",
     "prisma:seed": "tsx scripts/seed.ts",
     "e2e": "playwright test",
-    "vercel-build": "npm run build",
-    "postinstall": "prisma generate"
+    "vercel-build": "npm run build"
   },
   "dependencies": {
     "@auth/mongodb-adapter": "^3.10.0",

--- a/sewago/frontend/src/app/(dashboard)/account/login/page.tsx
+++ b/sewago/frontend/src/app/(dashboard)/account/login/page.tsx
@@ -2,6 +2,7 @@
 
 // Force dynamic rendering to prevent build-time prerendering
 export const dynamic = 'force-dynamic';
+export const revalidate = 0;
 
 import React, { useState } from 'react';
 import { signIn, getSession } from 'next-auth/react';

--- a/sewago/frontend/src/app/(dashboard)/layout.tsx
+++ b/sewago/frontend/src/app/(dashboard)/layout.tsx
@@ -1,3 +1,6 @@
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
 import DashboardHeader from '@/components/DashboardHeader';
 
 export default function DashboardLayout({


### PR DESCRIPTION
Disable static prerender on (dashboard) and /account/login via dynamic='force-dynamic' and evalidate=0. Remove prisma generate from frontend build (we proxy to the backend). Verified locally with 
ext build.